### PR TITLE
Keyguard: Clarify error message on bad input length.

### DIFF
--- a/packages/Keyguard/res/values/cm_strings.xml
+++ b/packages/Keyguard/res/values/cm_strings.xml
@@ -26,4 +26,7 @@
         <item quantity="one">Enter SIM PIN, you have <xliff:g id="number">%d</xliff:g> remaining attempt before you must contact your carrier to unlock your device.</item>
         <item quantity="other">Enter SIM PIN, you have <xliff:g id="number">%d</xliff:g> remaining attempts.</item>
     </plurals>
+
+    <!-- Shown in the KeyguardSimPinView when entry length is too short. -->
+    <string name="kg_invalid_sim_length">Error: Input shorter than minimum length</string>
 </resources>

--- a/packages/Keyguard/src/com/android/keyguard/KeyguardSimPinView.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardSimPinView.java
@@ -238,7 +238,7 @@ public class KeyguardSimPinView extends KeyguardPinBasedInputView {
 
         if (entry.length() < 4) {
             // otherwise, display a message to the user, and don't submit.
-            mSecurityMessageDisplay.setMessage(R.string.kg_invalid_sim_pin_hint, true);
+            mSecurityMessageDisplay.setMessage(R.string.kg_invalid_sim_length, true);
             resetPasswordText(true);
             mCallback.userActivity();
             return;


### PR DESCRIPTION
  If the input is shorter than the minimum requirement for
  PUK, then we need to alert the user with a more clarified
  error rather than simple text.

  TICKET: SAMBAR-587

Change-Id: I6bcf932b735891d763db54d6ba53ab7b538de720